### PR TITLE
Add IAM config for instance profiles

### DIFF
--- a/capacity-service.tf
+++ b/capacity-service.tf
@@ -55,7 +55,7 @@ resource "aws_elastic_beanstalk_environment" "capacity-service-env" {
   setting {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "IamInstanceProfile"
-    value     = "${aws_iam_instance_profile.eb-instance-profile.name}"
+    value     = "${aws_iam_instance_profile.a2si-eb.name}"
   }
 
   setting {

--- a/capacity-service.tf
+++ b/capacity-service.tf
@@ -53,6 +53,12 @@ resource "aws_elastic_beanstalk_environment" "capacity-service-env" {
   }
 
   setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "IamInstanceProfile"
+    value     = "${aws_iam_instance_profile.eb-instance-profile.name}"
+  }
+
+  setting {
     namespace = "aws:autoscaling:asg"
     name = "Availability Zones"
     value = "Any ${length(var.aws_azs)}"

--- a/dos-proxy.tf
+++ b/dos-proxy.tf
@@ -47,6 +47,12 @@ resource "aws_elastic_beanstalk_environment" "dos-proxy-env" {
   }
 
   setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "IamInstanceProfile"
+    value     = "${aws_iam_instance_profile.eb-instance-profile.name}"
+  }
+
+  setting {
     namespace = "aws:autoscaling:asg"
     name = "Availability Zones"
     value = "Any ${length(var.aws_azs)}"

--- a/dos-proxy.tf
+++ b/dos-proxy.tf
@@ -49,7 +49,7 @@ resource "aws_elastic_beanstalk_environment" "dos-proxy-env" {
   setting {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "IamInstanceProfile"
-    value     = "${aws_iam_instance_profile.eb-instance-profile.name}"
+    value     = "${aws_iam_instance_profile.a2si-eb.name}"
   }
 
   setting {

--- a/iam.tf
+++ b/iam.tf
@@ -1,4 +1,4 @@
-resource "aws_iam_role" "ebs-role" {
+resource "aws_iam_role" "a2si-eb" {
   name        = "a2si-elasticbeanstalk-ec2-role"
   description = ""
 
@@ -18,17 +18,17 @@ resource "aws_iam_role" "ebs-role" {
 EOF
 }
 
-resource "aws_iam_role_policy_attachment" "AWSElasticBeanstalkWebTier-attach" {
-  role       = "${aws_iam_role.ebs-role.name}"
+resource "aws_iam_role_policy_attachment" "AWSElasticBeanstalkWebTier" {
+  role       = "${aws_iam_role.a2si-eb.name}"
   policy_arn = "arn:aws:iam::aws:policy/AWSElasticBeanstalkWebTier"
 }
 
-resource "aws_iam_role_policy_attachment" "AWSElasticBeanstalkService-attach" {
-  role       = "${aws_iam_role.ebs-role.name}"
+resource "aws_iam_role_policy_attachment" "AWSElasticBeanstalkService" {
+  role       = "${aws_iam_role.a2si-eb.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSElasticBeanstalkService"
 }
 
-resource "aws_iam_instance_profile" "eb-instance-profile" {
-  name = "a2si-elasticbeanstalk-ec2-role-instance-profile"
-  role = "${aws_iam_role.ebs-role.name}"
+resource "aws_iam_instance_profile" "a2si-eb" {
+  name = "a2si-elasticbeanstalk-ec2-role"
+  role = "${aws_iam_role.a2si-eb.name}"
 }

--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,34 @@
+resource "aws_iam_role" "ebs-role" {
+  name        = "a2si-elasticbeanstalk-ec2-role"
+  description = ""
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "AWSElasticBeanstalkWebTier-attach" {
+  role       = "${aws_iam_role.ebs-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AWSElasticBeanstalkWebTier"
+}
+
+resource "aws_iam_role_policy_attachment" "AWSElasticBeanstalkService-attach" {
+  role       = "${aws_iam_role.ebs-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSElasticBeanstalkService"
+}
+
+resource "aws_iam_instance_profile" "eb-instance-profile" {
+  name = "a2si-elasticbeanstalk-ec2-role-instance-profile"
+  role = "${aws_iam_role.ebs-role.name}"
+}


### PR DESCRIPTION
When spinning up the stack in the London region, it gives the following error:

```
aws_elastic_beanstalk_environment.capacity-service-env: Still creating... (10s elapsed)

Error: Error applying plan:

1 error(s) occurred:

* aws_elastic_beanstalk_environment.capacity-service-env: 1 error(s) occurred:

* aws_elastic_beanstalk_environment.capacity-service-env: Error waiting for Elastic Beanstalk Environment (e-mt7f3i5bmq) to become ready: 2 error(s) occurred:

* 2018-06-11 19:31:29.28 +0000 UTC (e-mt7f3i5bmq) : Environment must have instance profile associated with it.
* 2018-06-11 19:31:29.39 +0000 UTC (e-mt7f3i5bmq) : Failed to launch environment.
```

This pull request creates a new role, adds the `AWSElasticBeanstalkWebTier` and `AWSElasticBeanstalkService` profiles to it, and then creates an InstanceProfile to allow that role to be attached to the Beanstalk apps on creation.

Would benefit from someone checking it works in a region other than eu-west-2 (London)